### PR TITLE
fetch api cache 설정

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="w-[100vw] h-[100vh]"></div>;
+}

--- a/src/app/movie-search/page.tsx
+++ b/src/app/movie-search/page.tsx
@@ -7,6 +7,8 @@ import { dehydrate, Hydrate } from '@tanstack/react-query';
 import { Metadata } from 'next';
 import Link from 'next/link';
 
+export const dynamic = 'force-dynamic';
+
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: '무비서치',

--- a/src/app/movie-talk/page.tsx
+++ b/src/app/movie-talk/page.tsx
@@ -10,6 +10,8 @@ import { Hydrate, dehydrate } from '@tanstack/react-query';
 import { Metadata } from 'next';
 import Link from 'next/link';
 
+export const dynamic = 'force-dynamic';
+
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: '무비토크',

--- a/src/app/movie/[movieId]/page.tsx
+++ b/src/app/movie/[movieId]/page.tsx
@@ -5,6 +5,8 @@ import getQueryClient from '@/service/queryClient';
 import { Hydrate, dehydrate } from '@tanstack/react-query';
 import { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 type Props = {
   params: {
     movieId: number;

--- a/src/app/movielog/[userId]/page.tsx
+++ b/src/app/movielog/[userId]/page.tsx
@@ -5,10 +5,11 @@ import getQueryClient from '@/service/queryClient';
 import { Hydrate, dehydrate } from '@tanstack/react-query';
 import { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 type Props = {
   params: { userId: number };
 };
-export const dynamic = 'force-dynamic';
 
 export async function generateMetadata({
   params: { userId },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import MovieTime from '@/components/Main/MovieTime/MovieTime';
 import ReviewTime from '@/components/Main/ReviewTime/ReviewTime';
 import { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: {
     default: `It's Movie Time`,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import MovieTime from '@/components/Main/MovieTime/MovieTime';
 import ReviewTime from '@/components/Main/ReviewTime/ReviewTime';
 import { Metadata } from 'next';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 3600 * 24;
 
 export const metadata: Metadata = {
   title: {

--- a/src/app/review/[reviewId]/page.tsx
+++ b/src/app/review/[reviewId]/page.tsx
@@ -7,6 +7,8 @@ import { getComments, getLikeInfo, getReview } from '@/service/review';
 import { Hydrate, dehydrate } from '@tanstack/react-query';
 import { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 type Props = {
   params: {
     reviewId: number;

--- a/src/app/search/movie/[value]/page.tsx
+++ b/src/app/search/movie/[value]/page.tsx
@@ -3,6 +3,8 @@ import getQueryClient from '@/service/queryClient';
 import { getMovieSearchResult } from '@/service/search';
 import { Hydrate, dehydrate } from '@tanstack/react-query';
 
+export const dynamic = 'force-dynamic';
+
 type Props = {
   params: {
     value: string;

--- a/src/app/search/user/[value]/page.tsx
+++ b/src/app/search/user/[value]/page.tsx
@@ -3,6 +3,8 @@ import getQueryClient from '@/service/queryClient';
 import { getUserSearchResult } from '@/service/search';
 import { Hydrate, dehydrate } from '@tanstack/react-query';
 
+export const dynamic = 'force-dynamic';
+
 type Props = {
   params: {
     value: string;

--- a/src/components/Main/MovieTime/MovieTime.tsx
+++ b/src/components/Main/MovieTime/MovieTime.tsx
@@ -7,7 +7,10 @@ import MovieTimeMoviesContainer from './MovieTimeMoviesContainer/MovieTimeMovies
 
 export default async function MovieTime() {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery<IMovieTime>(['movieTime'], getMovieTime);
+  await queryClient.prefetchQuery<IMovieTime>(['movieTime'], getMovieTime, {
+    cacheTime: 3600 * 2,
+    staleTime: 3600 * 2,
+  });
   const dehydratedState = dehydrate(queryClient);
   return (
     <section className="mt-[60px] w-full flex flex-col items-center">

--- a/src/components/Main/ReviewTime/ReviewTime.tsx
+++ b/src/components/Main/ReviewTime/ReviewTime.tsx
@@ -7,7 +7,10 @@ import ReviewTimeContainer from './ReviewTimeContainer/ReviewTimeContainer';
 
 export default async function ReviewTime() {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery<IMovieTime>(['reviewTime'], getReviewTime);
+  await queryClient.prefetchQuery<IMovieTime>(['reviewTime'], getReviewTime, {
+    cacheTime: 3600 * 2,
+    staleTime: 3600 * 2,
+  });
   const dehydratedState = dehydrate(queryClient);
   return (
     <section className="mt-[150px] w-full flex flex-col items-center ">


### PR DESCRIPTION
- 페이지 마다 'no-cache' 설정
- 메인 페이지만 revalidate 시간 하루로 설정
- 기본 로딩 컴포넌트 생성